### PR TITLE
Feature/add text plain mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ jmeter_log*
 .idea/
 *.iml
 *.iws
+
+#Java version management tools
+.java-version

--- a/src/main/java/io/vlingo/http/resource/DefaultTextPlainMapper.java
+++ b/src/main/java/io/vlingo/http/resource/DefaultTextPlainMapper.java
@@ -1,0 +1,26 @@
+// Copyright © 2012-2020 VLINGO LABS. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.http.resource;
+
+public class DefaultTextPlainMapper implements Mapper {
+  public static final Mapper instance = new DefaultTextPlainMapper();
+  
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T from(final String data, final Class<T> type) {
+    if (type.getName().equals("java.lang.String")) {
+      return (T) data;
+    }
+    throw new IllegalArgumentException("Cannot deserialize text into type");
+  }
+
+  @Override
+  public <T> String from(final T data) {
+    return data.toString();
+  }
+}

--- a/src/main/java/io/vlingo/http/resource/DefaultTextPlainMapper.java
+++ b/src/main/java/io/vlingo/http/resource/DefaultTextPlainMapper.java
@@ -7,6 +7,8 @@
 
 package io.vlingo.http.resource;
 
+import io.vlingo.xoom.http.resource.Mapper;
+
 public class DefaultTextPlainMapper implements Mapper {
   public static final Mapper instance = new DefaultTextPlainMapper();
   

--- a/src/main/java/io/vlingo/xoom/http/media/ContentMediaType.java
+++ b/src/main/java/io/vlingo/xoom/http/media/ContentMediaType.java
@@ -58,6 +58,8 @@ public class ContentMediaType extends MediaTypeDescriptor {
     return new ContentMediaType(mimeTypes.application.name(), "xml");
   }
 
+  public static  ContentMediaType PlainText() { return new ContentMediaType(mimeTypes.text.name(), "plain"); }
+
   public static ContentMediaType parseFromDescriptor(String contentMediaTypeDescriptor) {
     return MediaTypeParser.parseFrom(contentMediaTypeDescriptor,
       new MediaTypeDescriptor.Builder<>(ContentMediaType::new));

--- a/src/main/java/io/vlingo/xoom/http/resource/DefaultMediaTypeMapper.java
+++ b/src/main/java/io/vlingo/xoom/http/resource/DefaultMediaTypeMapper.java
@@ -6,6 +6,10 @@ public class DefaultMediaTypeMapper  {
 
   private static MediaTypeMapper instance = buildInstance();
 
+  private DefaultMediaTypeMapper() {
+    // no-op
+  }
+
   private static MediaTypeMapper buildInstance() {
     return new MediaTypeMapper.Builder()
       .addMapperFor(ContentMediaType.Json(), DefaultJsonMapper.instance)

--- a/src/test/java/io/vlingo/http/resource/DefaultTextPlainMapperTest.java
+++ b/src/test/java/io/vlingo/http/resource/DefaultTextPlainMapperTest.java
@@ -1,0 +1,37 @@
+package io.vlingo.http.resource;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultTextPlainMapperTest {
+
+  @Test
+  public void testFromObjectToStringUsesToString() {
+    DefaultTextPlainMapper mapper = new DefaultTextPlainMapper();
+    assertEquals("toStringResult", mapper.from(new ObjectForTest()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDeserializationToNonStringFails() {
+    DefaultTextPlainMapper mapper = new DefaultTextPlainMapper();
+    ObjectForTest cannotBeDeserialized = mapper.from("some string", ObjectForTest.class);
+  }
+
+  @Test
+  public void testDeserializationToStringSucceed() {
+    DefaultTextPlainMapper mapper = new DefaultTextPlainMapper();
+    String canBeSerialized = mapper.from("some string", String.class);
+    assertEquals("some string", canBeSerialized);
+  }
+
+  private static class ObjectForTest {
+
+    @Override
+    public String toString() {
+      return "toStringResult";
+    }
+  }
+}


### PR DESCRIPTION

 * Add mapper that serializes to string and deserializes only to a String-class result
 * This will not be used for response, unless the client so requests, by specifying the accepted content header, etc.
 * Minor fix for missing private constructor (from sonar)
