### PR TITLE
Improvement/remote address

### DIFF
--- a/src/main/java/io/vlingo/xoom/http/resource/Configuration.java
+++ b/src/main/java/io/vlingo/xoom/http/resource/Configuration.java
@@ -9,6 +9,8 @@
 
 package io.vlingo.xoom.http.resource;
 
+import io.vlingo.xoom.http.Filters;
+
 import java.util.Properties;
 
 public class Configuration {
@@ -17,6 +19,7 @@ public class Configuration {
   private int port;
   private Sizing sizing;
   private Timing timing;
+  private Filters filters;
 
   public static Configuration define() {
     instance = new Configuration();
@@ -43,6 +46,11 @@ public class Configuration {
     return this;
   }
 
+  public Configuration with(final Filters filters) {
+    this.filters = filters;
+    return this;
+  }
+
   public int port() {
     return this.port;
   }
@@ -55,10 +63,15 @@ public class Configuration {
     return this.timing;
   }
 
+  public Filters filters() {
+    return filters;
+  }
+
   private Configuration() {
     this.port = 8080;
     this.sizing = Sizing.define();
     this.timing = new Timing(4, 2, 100);
+    this.filters = Filters.none();
   }
 
   private Configuration(final Properties properties) {

--- a/src/main/java/io/vlingo/xoom/http/resource/ServerActor.java
+++ b/src/main/java/io/vlingo/xoom/http/resource/ServerActor.java
@@ -7,6 +7,7 @@
 
 package io.vlingo.xoom.http.resource;
 
+import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +44,8 @@ import io.vlingo.xoom.wire.fdx.bidirectional.ServerRequestResponseChannel;
 import io.vlingo.xoom.wire.message.BasicConsumerByteBuffer;
 import io.vlingo.xoom.wire.message.ConsumerByteBuffer;
 import io.vlingo.xoom.wire.message.ConsumerByteBufferPool;
+
+import static io.vlingo.xoom.http.RequestHeader.XForwardedFor;
 
 public class ServerActor extends Actor implements Server, HttpRequestChannelConsumerProvider, Scheduled<Object> {
   static final String ChannelName = "server-request-response-channel";
@@ -323,7 +326,8 @@ public class ServerActor extends Actor implements Server, HttpRequestChannelCons
         Context context = null;
 
         while (parser.hasFullRequest()) {
-          context = consume(requestResponseContext, parser.fullRequest(), wasIncompleteContent);
+          final Request enrichedRequest = enrichRequest(requestResponseContext, parser.fullRequest());
+          context = consume(requestResponseContext, enrichedRequest, wasIncompleteContent);
         }
 
         if (parser.isMissingContent() && !requestsMissingContent.containsKey(requestResponseContext.id())) {
@@ -346,6 +350,16 @@ public class ServerActor extends Actor implements Server, HttpRequestChannelCons
         buffer.release();
       }
     }
+
+    private Request enrichRequest(final RequestResponseContext<?> requestResponseContext, final Request request) {
+      try {
+        request.headers.add(RequestHeader.of(XForwardedFor, requestResponseContext.remoteAddress()));
+      } catch (UnsupportedOperationException exception) {
+        logger().error("Unable to enrich request headers");
+      }
+      return request;
+    }
+
 
     @Override
     public void consume(final RequestResponseContext<?> requestResponseContext, final Request request) {

--- a/src/main/java/io/vlingo/xoom/http/resource/ServerActor.java
+++ b/src/main/java/io/vlingo/xoom/http/resource/ServerActor.java
@@ -354,7 +354,7 @@ public class ServerActor extends Actor implements Server, HttpRequestChannelCons
     private Request enrichRequest(final RequestResponseContext<?> requestResponseContext, final Request request) {
       try {
         request.headers.add(RequestHeader.of(XForwardedFor, requestResponseContext.remoteAddress()));
-      } catch (UnsupportedOperationException exception) {
+      } catch (final UnsupportedOperationException exception) {
         logger().error("Unable to enrich request headers");
       }
       return request;


### PR DESCRIPTION
@VaughnVernon 
These changes make `IP address` accessible from the Request headers. Also, a `Filters` member was added in the server configuration class so that it's easier to create request/response filters in [XoomInitializationAware](https://github.com/vlingo/xoom-turbo/blob/master/src/main/java/io/vlingo/xoom/turbo/XoomInitializationAware.java) subclasses.