### PR TITLE
Consistently generate the UserResource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,19 +99,19 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>1.32</version>
+      <version>1.33</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>1.32</version>
+      <version>1.33</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.10.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.graalvm.sdk</groupId>

--- a/src/test/java/io/vlingo/xoom/http/resource/ResourceDispatcherGeneratorTest.java
+++ b/src/test/java/io/vlingo/xoom/http/resource/ResourceDispatcherGeneratorTest.java
@@ -26,6 +26,7 @@ public class ResourceDispatcherGeneratorTest {
   private Action actionGetUser;
   private Action actionGetUsers;
   private Action actionQueryUserError;
+  private Action actionPutUser;
   private List<Action> actions;
   private ConfigurationResource<?> resource;
 
@@ -68,6 +69,7 @@ public class ResourceDispatcherGeneratorTest {
     actionGetUser = new Action(3, "GET", "/users/{userId}", "queryUser(String userId)", null);
     actionGetUsers = new Action(4, "GET", "/users", "queryUsers()", null);
     actionQueryUserError = new Action(5, "GET", "/users/{userId}/error", "queryUserError(String userId)", null);
+    actionPutUser = new Action(6, "PUT", "/users/{userId}", "changeUser(String userId, body:io.vlingo.xoom.http.sample.user.UserData userData)", null);
 
     actions =
             Arrays.asList(
@@ -76,7 +78,8 @@ public class ResourceDispatcherGeneratorTest {
                     actionPatchUserName,
                     actionGetUser,
                     actionGetUsers,
-                    actionQueryUserError);
+                    actionQueryUserError,
+                    actionPutUser);
 
     Class<? extends ResourceHandler> resourceHandlerClass = null;
 

--- a/src/test/java/io/vlingo/xoom/http/resource/ResourcesTest.java
+++ b/src/test/java/io/vlingo/xoom/http/resource/ResourcesTest.java
@@ -36,15 +36,15 @@ public class ResourcesTest {
     
     for (Action action : user.actions) {
       ++countUserActions;
-      
-      assertTrue(action.method.isPOST() || action.method.isPATCH() || action.method.isGET());
+
+      assertTrue(action.method.isPOST() || action.method.isPATCH() || action.method.isPUT() || action.method.isGET());
       
       assertNotNull(action.uri);
       assertNotNull(action.to);
       assertNotNull(action.mapper);
     }
     
-    assertEquals(6, countUserActions);
+    assertEquals(7, countUserActions);
     
     final ConfigurationResource<?> profile = (ConfigurationResource<?>) resources.resourceOf("profile");
     
@@ -102,6 +102,7 @@ public class ResourcesTest {
                               .also("PATCH", "/users/{userId}/name", "changeName(String userId, body:io.vlingo.xoom.http.sample.user.NameData nameData)")
                               .also("GET", "/users/{userId}", "queryUser(String userId)")
                               .also("GET", "/users", "queryUsers()")
+                              .also("PUT", "/users/{userId}", "changeUser(String userId, body:io.vlingo.xoom.http.sample.user.UserData userData)")
                               .thatsAll()),
                    ConfigurationResource.defining("profile", ProfileResource.class, 5,
                       Actions.canBe("PUT", "/users/{userId}/profile", "define(String userId, body:io.vlingo.xoom.http.sample.user.ProfileData profileData)", "io.vlingo.xoom.http.sample.user.ProfileDataMapper")

--- a/src/test/java/io/vlingo/xoom/http/resource/ServerTest.java
+++ b/src/test/java/io/vlingo/xoom/http/resource/ServerTest.java
@@ -96,11 +96,11 @@ public abstract class ServerTest extends ResourceTestFixtures {
     assertEquals(1, progress.consumeCount.get());
     assertNotNull(createdResponse.headers.headerOf(ResponseHeader.Location));
 
+    final AccessSafely moreConsumeCalls = progress.expectConsumeTimes(1);
     final String getUserMessage = "GET " + createdResponse.headerOf(ResponseHeader.Location).value + " HTTP/1.1\nHost: vlingo.io\nConnection: keep-alive\n\n";
 
     client.requestWith(toByteBuffer(getUserMessage));
 
-    final AccessSafely moreConsumeCalls = progress.expectConsumeTimes(1);
     while (moreConsumeCalls.totalWrites() < 1) {
       client.probeChannel();
     }

--- a/src/test/java/io/vlingo/xoom/http/resource/ServerTest.java
+++ b/src/test/java/io/vlingo/xoom/http/resource/ServerTest.java
@@ -155,8 +155,8 @@ public abstract class ServerTest extends ResourceTestFixtures {
   }
 
   @Test
-  public void testThatServerRespondsPermanentRedirectWithNoContentLengthHeader() {
-    System.out.println(">>>>>>>>>>>>>>>>>>>>> testThatServerRespondsPermanentRedirectWithNoContentLengthHeader");
+  public void testThatServerRespondsPermanentRedirect() {
+    System.out.println(">>>>>>>>>>>>>>>>>>>>> testThatServerRespondsPermanentRedirect");
 
     if (skipTests) {
       System.out.println(">>>>>>>>>>>>>>>>>>>>> skipped");
@@ -178,11 +178,12 @@ public abstract class ServerTest extends ResourceTestFixtures {
     assertNotNull(response);
     assertEquals(PermanentRedirect.name(), response.status.name());
     assertEquals(1, progress.consumeCount.get());
+    assertEquals("0", response.headers.headerOf("Content-Length").value);
   }
 
   @Test
-  public void testThatServerRespondsOkWithNoContentLengthHeader() {
-    System.out.println(">>>>>>>>>>>>>>>>>>>>> testThatServerRespondsOkWithNoContentLengthHeader");
+  public void testThatServerRespondsOk() {
+    System.out.println(">>>>>>>>>>>>>>>>>>>>> testThatServerRespondsOk");
 
     if (skipTests) {
       System.out.println(">>>>>>>>>>>>>>>>>>>>> skipped");
@@ -204,6 +205,7 @@ public abstract class ServerTest extends ResourceTestFixtures {
     assertNotNull(response);
     assertEquals(Ok.name(), response.status.name());
     assertEquals(1, progress.consumeCount.get());
+    assertEquals("0", response.headers.headerOf("Content-Length").value);
   }
 
   @Test

--- a/src/test/resources/xoom-http.properties
+++ b/src/test/resources/xoom-http.properties
@@ -61,7 +61,7 @@ feed.resource.events.pool = 10
 # user resources
 #=====================================
 
-resource.name.user = [register, contact, name, queryUser, queryUsers, queryUserError]
+resource.name.user = [register, contact, name, queryUser, queryUsers, queryUserError, changeUser]
 
 resource.user.handler = io.vlingo.xoom.http.sample.user.UserResource
 resource.user.pool = 10
@@ -90,6 +90,10 @@ action.user.queryUsers.to = queryUsers()
 action.user.queryUserError.method = GET
 action.user.queryUserError.uri = /user/{userId}/error
 action.user.queryUserError.to = queryUserError(String userId)
+
+action.user.changeUser.method = PUT
+action.user.changeUser.uri = /users/{userId}
+action.user.changeUser.to = changeUser(String userId, body:io.vlingo.xoom.http.sample.user.UserData userData)
 
 #=====================================
 # profile resources


### PR DESCRIPTION
Otherwise, if `ResourceDispatcherGeneratorTest` or `ResourcesTest` happen to run before the `ServerAgentTest`, the generated `UserResourceDispatcher` will not have code handling the PUT action.